### PR TITLE
Fix plugin youtube.inc.php 横幅が画面からはみ出ないように

### DIFF
--- a/plugin/youtube.inc.php
+++ b/plugin/youtube.inc.php
@@ -33,9 +33,11 @@ function plugin_youtube_convert()
 	if (func_num_args() < 1) return FALSE;
 	$args = func_get_args();
 	$name = trim($args[0]);
-	$body = '<iframe width="640" height="360" src="//www.youtube.com/embed/' .$name .'" frameborder="0" allowfullscreen="true"></iframe>';
+	$body = <<<EOF
+		<iframe src="//www.youtube.com/embed/${name}" frameborder="0" allowfullscreen="true"
+			style="display: inline-block;max-width: 100%;width: 640px;height: fit-content;aspect-ratio: 16/9;"></iframe>
+	EOF;
 	return $body . "\n";
-
 }
 
 


### PR DESCRIPTION
follow up #7 

スマホなどの横が狭いレイアウトで youtube がはみ出るのをなおす。

| before | after |
| --- | --- |
| ![image](https://github.com/mgmn/pukiwiki/assets/5103195/3a898233-8287-4558-a9a0-9be877334578) | ![image](https://github.com/mgmn/pukiwiki/assets/5103195/c45d90dd-a9b7-4aef-9870-7efd99b6f0d3) |

